### PR TITLE
NEW: all functions with the userId/traderId as an input now accepts:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .secret/
 /playwright-report/
 /dist/
+/integration-test/test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 
+## [0.11.0] – 2022-12-14
+
+### New
+
+- all functions with the userId/traderId as an input now accepts:
+    1) hex string with `0x` prefix;
+    2) hex string of 64 char length without `0x` prefix;
+    3) decimal string.
+
 ## [0.10.2] – 2022-12-14
 
 ### Fixed

--- a/examples/delegate-evers.ts
+++ b/examples/delegate-evers.ts
@@ -1,7 +1,6 @@
 import { Flex, Trader } from "../flex";
 import { CONFIG, EXAMPLES_FLEX_CONFIG } from "./examples";
 
-
 (async () => {
     const flex = new Flex(EXAMPLES_FLEX_CONFIG);
     try {
@@ -14,20 +13,17 @@ import { CONFIG, EXAMPLES_FLEX_CONFIG } from "./examples";
             tokens: 100,
             evers: 20,
             keepEvers: 15,
-            traderId: traderId,
+            traderId,
             ...CONFIG.tip3.EVER,
         });
 
         flex.evr.log.info("Trader EVER wallet address:", trader_ever_wallet, "has been topped-up.");
         flex.evr.log.info(
             "Trader balances:",
-            await Trader.queryWallets(
-                flex,
-                {
-                    clientAddress: clientAddress,
-                    traderId: traderId,
-                },
-            ),
+            await Trader.queryWallets(flex, {
+                clientAddress: clientAddress,
+                traderId,
+            }),
         );
 
         await flex.close();

--- a/examples/delegate-tip3.ts
+++ b/examples/delegate-tip3.ts
@@ -11,7 +11,7 @@ import { CONFIG, EXAMPLES_FLEX_CONFIG } from "./examples";
         let trader_tip3_wallet = await Trader.deployTip31Wallet(flex, {
                 clientAddress: clientAddress,
                 everWallet: CONFIG.everWallet,
-                traderId: traderId,
+                traderId,
                 tokenUnits: "10000000000",
                 transferEvers: 21,
                 evers: 20,
@@ -27,7 +27,7 @@ import { CONFIG, EXAMPLES_FLEX_CONFIG } from "./examples";
                 flex,
                 {
                     clientAddress: clientAddress,
-                    traderId: traderId,
+                    traderId,
                 },
             ),
         );

--- a/flex/trader/index.ts
+++ b/flex/trader/index.ts
@@ -247,7 +247,7 @@ export class Trader {
     /**
      * Tops up Trader's wallets and UserIndex account.
      * Tops up to the minimum balance specified + additional value on top.
-     * Topup value will be equal to (TopUpOptions.minBalance - current balance + TopUpOptions.value) for each account.
+     * Top up value will be equal to (TopUpOptions.minBalance - current balance + TopUpOptions.value) for each account.
      * @param flex
      * @param options
      * @returns
@@ -257,7 +257,7 @@ export class Trader {
     }
 
     /**
-     * Returns the list of accounts that require topup, with amount of
+     * Returns the list of accounts that require top up, with amount of
      * TopUpResult.totalTopUpValue = (TopUpOptions.minBalance - account.balance + TopUpOptions.value)
      * @param flex
      * @param options

--- a/flex/trader/query.ts
+++ b/flex/trader/query.ts
@@ -3,8 +3,9 @@ import { Market } from "../market";
 import { Token } from "../token";
 import { WalletInfo, walletInfoFromApi } from "../client";
 import { OrderInfo, TradeInfo } from "./types";
+import { uint256 } from "../web3";
 
-function orderInfoInfoFromApi(result: any): OrderInfo {
+function orderInfoFromApi(result: any): OrderInfo {
     return {
         orderId: result.orderId,
         traderId: result.userId,
@@ -22,7 +23,7 @@ function orderInfoInfoFromApi(result: any): OrderInfo {
 /** @internal */
 export async function queryOrders(flex: Flex, trader: string): Promise<OrderInfo[]> {
     const result = await flex.query(`
-            userOrders(userId:"0x${trader}") {
+            userOrders(userId:"${uint256(trader)}") {
                 pair { ${Market.queryFields()} }
                 side
                 price
@@ -35,7 +36,7 @@ export async function queryOrders(flex: Flex, trader: string): Promise<OrderInfo
                 finishTime
             }
         `);
-    return result.userOrders.map(orderInfoInfoFromApi);
+    return result.userOrders.map(orderInfoFromApi);
 }
 
 function tradeFromApi(result: any): TradeInfo {
@@ -56,7 +57,7 @@ function tradeFromApi(result: any): TradeInfo {
 /** @internal */
 export async function queryTrades(flex: Flex, trader: string): Promise<TradeInfo[]> {
     const result = await flex.query(`
-        userTrades(userId:"0x${trader}") {
+        userTrades(userId:"${uint256(trader)}") {
             pair { ${Market.queryFields()} }
             price
             amount
@@ -92,7 +93,7 @@ export async function queryWallets(
     const result = await flex.query(`
         wallets(
             clientAddress: "${options.clientAddress}"
-            ${options.traderId ? `userId: "0x${options.traderId}"` : ""}
+            ${options.traderId ? `userId: "${uint256(options.traderId)}"` : ""}
             ${options.token ? `token: "${options.token}",` : ""}
         ) {
             address

--- a/flex/web3/utils.ts
+++ b/flex/web3/utils.ts
@@ -8,7 +8,10 @@ export function uint256(value: string): string {
     if (value.startsWith("0x") || value.startsWith("0X")) {
         return value;
     }
-    return `0x${value}`;
+    if (value.length === 64) {
+        return `0x${value}`;
+    }
+    return `0x${BigInt(value).toString(16)}`;
 }
 
 export type DecimalNumber = number | bigint | string;

--- a/integration-test/05-query.test.ts
+++ b/integration-test/05-query.test.ts
@@ -1,5 +1,5 @@
 import { expect, test as base } from "./config"
-import { Token, Client, EverWallet, Market, SignerOption, Trader, TradeSide, TokenValue, PriceOrder, MakeOrderResult } from "../flex"
+import { Token, Client, EverWallet, Market, SignerOption, Trader, TradeSide, TokenValue, PriceOrder, MakeOrderResult, uint256 } from "../flex"
 import { signerKeys } from "@eversdk/core";
 
 type HelperFixtures = {
@@ -344,7 +344,7 @@ test.describe('Trader', () => {
                     token: expect.objectContaining({
                         ticker: config.TSDT.ticker,
                     }),
-                    traderId: `0x${traderId}` // FIXME
+                    traderId: uint256(traderId)
                 }),
                 expect.objectContaining({
                     address: accounts.EVER.internalAddress,
@@ -354,7 +354,7 @@ test.describe('Trader', () => {
                     token: expect.objectContaining({
                         ticker: config.EVER.ticker
                     }),
-                    traderId: `0x${traderId}` // FIXME
+                    traderId: uint256(traderId)
                 })
             ])
         )

--- a/integration-test/07-conversions.test.ts
+++ b/integration-test/07-conversions.test.ts
@@ -1,0 +1,16 @@
+import { test } from "./config";
+import { expect } from "@playwright/test";
+import { uint256 } from "../flex";
+
+test.describe("Conversions", () => {
+    test("uint256", async () => {
+        expect(uint256("1")).toBe("0x1");
+        expect(uint256("16")).toBe("0x10");
+        expect(uint256("255")).toBe("0xff");
+        expect(uint256("0x1")).toBe("0x1");
+        expect(uint256("0x01")).toBe("0x01");
+        expect(uint256("a1125f809825a8a2524e03469b70b4087300d95b9799a6d4908ba748ff0b7bd9")).toBe("0xa1125f809825a8a2524e03469b70b4087300d95b9799a6d4908ba748ff0b7bd9");
+        expect(uint256("0xa1125f809825a8a2524e03469b70b4087300d95b9799a6d4908ba748ff0b7bd9")).toBe("0xa1125f809825a8a2524e03469b70b4087300d95b9799a6d4908ba748ff0b7bd9");
+        expect(() => uint256("825a8a2524e03469b70b4087300d95b9799a6d4908ba748ff0b7bd9")).toThrow(/^Cannot convert/);
+    });
+});


### PR DESCRIPTION
    1) hex string with `0x` prefix;
    2) hex string of 64 char length without `0x` prefix;
    3) decimal string.

SDK-4253